### PR TITLE
Fix onChangeVisibleRows not being called in certain condition.

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -618,7 +618,7 @@ var ListView = React.createClass({
         var min = isVertical ? frame.y : frame.x;
         var max = min + (isVertical ? frame.height : frame.width);
         if ((!min && !max) || (min === max)) {
-          break;
+          continue;
         }
         if (min > visibleMax || max < visibleMin) {
           if (rowVisible) {


### PR DESCRIPTION
When computing row visibility changes, the ListView would stop if encountering an empty frame. However, an empty frame can sometimes occur in valid situations, specifically if the list is scrolled very early during its initialization process. In that case, `onChangeVisibleRows` would not be called.

This change causes the visibility calculation to simply skip the empty frame, instead of stopping the whole calculation.

This change is not 'dangerous' in any way, because the affected method, `_updateVisibleRows`, is only called in order to figure out whether `onChangeVisibleRows` has to be called or not.